### PR TITLE
Remove black background from svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,6 @@
 
 			<div id="chartfile">
 				<div id="cover">
-					<img id="image">
-					
 					<svg width="72" height="72">
 						<circle cx="36" cy="36" r="30" id="remaining"></circle>
 						<circle cx="36" cy="36" r="30" id="progress"></circle>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@
 					<img id="image">
 					
 					<svg width="72" height="72">
-						<rect width="72" height="72" id="darken"></rect>
 						<circle cx="36" cy="36" r="30" id="remaining"></circle>
 						<circle cx="36" cy="36" r="30" id="progress"></circle>
 					</svg>


### PR DESCRIPTION
In my opinion, the black background makes the overlay look unfinished when I see it on stream.

Before:
![blackbg](https://user-images.githubusercontent.com/16869835/97956916-b40fd580-1d5e-11eb-9f3c-c92dd359fd56.png)

After:
![nobg](https://user-images.githubusercontent.com/16869835/97956917-b4a86c00-1d5e-11eb-8746-2aa3514e9e06.png)
