### PR TITLE
Increase stats font from 10px to 12px

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,7 +80,7 @@ body {
 #difficulty, #nps, #rating {
 	display: inline-block;
 
-	font-size: 10px;
+	font-size: 12px;
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 3px;


### PR DESCRIPTION
In my opinion, the 10px can be a bit hard to read on stream at times. Bumping up the size slightly to try to make it more clear.

10px:
![10px](https://user-images.githubusercontent.com/16869835/97957369-db1ad700-1d5f-11eb-997f-b1b74bfd84f8.png)

12px:
![12px](https://user-images.githubusercontent.com/16869835/97957371-dbb36d80-1d5f-11eb-96f0-1ecc4e22edce.png)
